### PR TITLE
fix the declare_and_export example

### DIFF
--- a/type_reflect/examples/declare_and_export/declare_and_export.rs
+++ b/type_reflect/examples/declare_and_export/declare_and_export.rs
@@ -120,7 +120,7 @@ fn main() {
         destinations: [
             TypeScript(
                 "./type_reflect/examples/declare_and_export/output/type_2.ts"
-                prefix: "import { Bar } from './bar.ts'",
+                prefix: "import { Bar } from './bar.ts';",
                 tab_size: 2,
 
             ),


### PR DESCRIPTION
Currently the example fails with:

```
$ cargo run --example declare_and_export
...
Error formatting typescript: Expected ';', got 'export' at file:///type_2.ts:1:31

  import { Bar } from './bar.ts'export type Foo = { bar: Bar;  }  ; 
                                ~~~~~~
$
```

With this tweak it runs successfully to completion.